### PR TITLE
fix: no panic in removeEmptyFolder

### DIFF
--- a/util/file.go
+++ b/util/file.go
@@ -56,7 +56,7 @@ func RemoveEmptyDir(dir string) {
 		return err
 	})
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	fileNamesAll := strings.Join(fileNames, "")


### PR DESCRIPTION
Avoid panic without access to the directory permissions.