### PR TITLE
Fix wrong maven URL generation if forge version is not latest one

### DIFF
--- a/server/forge.go
+++ b/server/forge.go
@@ -47,6 +47,8 @@ func (inst *ForgeInstaller) Install(serverDir string, serverFile string) error {
 		}
 
 		version = sorted[0].String()
+	} else {
+		version = inst.MinecraftVersion + "-" + version
 	}
 
 	u := fmt.Sprintf(


### PR DESCRIPTION
Currently if version of forge is not latest, the code will try to fetch from wrong URL and fail with 404

Seems like this small patch fixes it