### PR TITLE
Verify Environment Support with API

### DIFF
--- a/modrinth/mrpack/index.go
+++ b/modrinth/mrpack/index.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nothub/mrpack-install/web/download"
 	"io"
 	"log"
+	"net/url"
 	"strings"
 )
 
@@ -113,7 +114,26 @@ func ReadIndex(zipFile string) (*Index, error) {
 
 func (index *Index) ServerDownloads(filter func(f File) bool) []*download.Download {
 	var downloads []*download.Download
+	projectIds := getProjectIds(index.Files)
+	projects, projErr := modrinth.Client.GetProjects(projectIds)
+	if projErr != nil {
+		projects = nil
+		log.Println("Error getting projects! You may see client mods appear.")
+	}
 	for _, file := range index.Files {
+		if projects != nil {
+			fid := getFileProjectId(file)
+			project := findProjectById(projects, fid)
+			if project != nil {
+				if project.ServerSide == modrinth.UnsupportedEnvSupport {
+					log.Printf("Skipped project %v\n", project.Title)
+					continue
+				}
+			} else {
+				log.Printf("Project at %v was not found online! Please verify this is not a client mod.\n", file.Path)
+			}
+		}
+
 		if file.Env.Server == modrinth.UnsupportedEnvSupport {
 			continue
 		}
@@ -134,4 +154,39 @@ func (index *Index) ServerDownloads(filter func(f File) bool) []*download.Downlo
 		})
 	}
 	return downloads
+}
+
+func getFileProjectId(file File) string {
+	if len(file.Downloads) <= 0 {
+		log.Printf("No downloads for file: %s\n", file.Path)
+		return ""
+	}
+	u, urlerr := url.Parse(file.Downloads[0])
+	if urlerr != nil {
+		log.Printf("Could not parse URL for file: %s\n", file.Path)
+		return ""
+	}
+	// Extract the ID
+	urlPath := u.Path
+	urlSplit := strings.Split(urlPath, "/")
+	// Assume data/{id}/...
+	projectId := urlSplit[2]
+	return projectId
+}
+
+func getProjectIds(files []File) []string {
+	ids := make([]string, len(files))
+	for i, file := range files {
+		ids[i] = getFileProjectId(file)
+	}
+	return ids
+}
+
+func findProjectById(projects []*modrinth.Project, projectId string) *modrinth.Project {
+	for _, project := range projects {
+		if project.Id == projectId {
+			return project
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
While setting up a modpack server with mrpack-installer, I noticed that after installing, I was getting errors from mods that looked to be Client only. I had some mods called [MacOS Input Fixes](https://modrinth.com/mod/macos-input-fixes), [Satisfying Buttons](https://modrinth.com/mod/satisfying-buttons), [Particle Effects](https://modrinth.com/mod/particle-effects), among many others being installed, which were all causing errors when trying to boot my server.

I first checked the issues page for a reported issue and came across #55 , which was explained that the issue was with the `modrinth.index.json` file which would make sense. I looked at the mod file, and sure enough, I found the culprit

```json
{
  "path": "mods/satisfying_buttons-fabric-1.1.2-1.21.1.jar",
  "hashes": {
    "sha1": "512e9bd5c5857ba59e2846ed0d9a485cddee2743",
    "sha512": "40781bf7fbfb58f50df277fa6d92e2e82adcfe7e53e51edf52f7bb3107a4d8e3c6733079c024bdd3a0854b3e36c7a98360b2e4c2f343ece09932dc227005a5e1"
  },
  "env": {
    "server": "required",
    "client": "required"
  },
  "downloads": [
    "https://cdn.modrinth.com/data/Zf8HMFM5/versions/dq128fRk/satisfying_buttons-fabric-1.1.2-1.21.1.jar"
  ],
  "fileSize": 680079
}
```

You can clearly see the server property under env is labeled as `required`, even though having this mod installed on the server will crash it. I went to check it on modrinth to see if it really was labeled as Client or Server, yet to my surprise, it is labeled as a Client only mod. So that proved to me that there is a difference between the mrpack's index and the modrinth's package online. Why this is the case? I'm not sure, this could purely be by design and I just don't understand how it works. Regardless, this was an issue for my specific use case (and likely many other's).

That is what this PR will solve. When collecting the downloads, the installer will now pull all the package info for every resource required and check its `server_side` property (which is what the modrinth website sees). As a comparison to the modrinth index file, here is what Satisfying Button's response looks like from the API

```json
{
  "client_side": "required",
  "server_side": "unsupported",
  "game_versions": [
    "1.18.2",
    "1.19.2",
    "1.20",
    "1.20.1",
    "1.21.1"
  ],
  "id": "Zf8HMFM5",
  "slug": "satisfying-buttons",
  "project_type": "mod",
  "team": "VdHeRWjc",
  "organization": null,
  "title": "Satisfying Buttons",
  "description": "Adds button sounds and enhanced hover effects.",
  "body": "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube-nocookie.com/embed/039TrXtZD08\" title=\"YouTube video player\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen></iframe>\n\n> _Satisfying Buttons used to create fiery button animations in Prominence II RPG_\n\nEver notice Minecraft's buttons are completely silent? Most other modern games have a subtle tick noise to simulate haptic feedback when hovering over a UI element. This mod adds that. It's a simple change but makes navigating the main menu much more satisfying.\n\nThis mod also adds **fade in effects** between the hovered and unhovered textures, allowing modpack developers to add fancy animation effects to their buttons. By default, it also adds a slight dark overlay when hovering over a button, which can be adjusted to a different color/opacity or disabled in the config.\n\nBoth button sounds and hover effects are configurable and able to be turned off individually. The volume and pitch of the sound is configurable, and you can override the sound file with a resource pack.\n\nHere is a demo video of what the default vanilla configuration looks like:\n\n<iframe width=\"560\" height=\"315\" src=\"https://www.youtube-nocookie.com/embed/lpDF_YdFZjY\" title=\"YouTube video player\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen></iframe>\n\n[Discord](https://discord.gg/kS7auUeYmc)",
  "body_url": null,
  "published": "2024-02-09T20:18:38.720482Z",
  "updated": "2024-09-17T18:57:30.711344Z",
  "approved": "2024-02-19T23:06:10.084994Z",
  "queued": "2024-02-09T20:57:07.471211Z",
  "status": "approved",
  "requested_status": "approved",
  "moderator_message": null,
  "license": {
    "id": "LicenseRef-Tonis-MMC-License",
    "name": "",
    "url": "https://gist.githubusercontent.com/nthxny/42d45dd915bb19af3789d498ef13b022/raw/192fc5295c5861a0df078a45fa677e7fa5596516/gistfile1.txt"
  },
  "downloads": 267023,
  "followers": 95,
  "categories": [],
  "additional_categories": [],
  "loaders": [
    "fabric",
    "forge",
    "neoforge"
  ],
  "versions": [
    "ZN4A2Qc5",
    "Z8H2I2bG",
    "zcRx0C7W",
    "WYhhoJXQ",
    "55aTIXu1",
    "uO0Yn43P",
    "MkqZhBVj",
    "VBRJARGP",
    "yTqcztsz",
    "bVFZKQi1",
    "rgSAg3Xc",
    "ftZac5qD",
    "xlFrZHFh",
    "FfUDYCOV",
    "f4Z6ZJjU",
    "2un87od3",
    "EssE56Wf",
    "1hVdykqq",
    "QscaKxur",
    "dq128fRk"
  ],
  "icon_url": "https://cdn.modrinth.com/data/Zf8HMFM5/ad4d2dc2c85d7e94bb853dd0269a48dbbd60b293_96.webp",
  "issues_url": "https://github.com/nthxny/SatisfyingButtons/issues",
  "source_url": "https://github.com/nthxny/SatisfyingButtons",
  "wiki_url": null,
  "discord_url": "https://discord.gg/kS7auUeYmc",
  "donation_urls": [],
  "gallery": [],
  "color": 15700095,
  "thread_id": "jD3Qp9Mn",
  "monetization_status": "monetized"
}
```

Notice how in this response, the `server_side` property is marked as `unsupported`, which is the correct value for this mod! Any other resources with a value of `unsupported` for the server will also be skipped when downloading, fixing most issues.

However, this is not perfect. After this I ran into a problem with dependencies. For example, the [FancyMenu](https://modrinth.com/mod/fancymenu) mod. This mod is reliant on the [Melody](https://modrinth.com/mod/melody) mod *even on the server*, regardless of the fact that it is marked as Client only. This is likely a fault by the mod developer, since this mod is marked specifically for the Client, yet FancyMod relies on it in a server environment. However, this is entirely open for perception; you may see this as a fault of Melody's for not being Client or Server and vice versa.